### PR TITLE
Limit the parser regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
   - The script now exits with code 1 if an error is raised.
+  - The script now allows for a PROFILE message containing `]` characters. 
 
 ### Changed
 

--- a/puppet-profile-parser.rb
+++ b/puppet-profile-parser.rb
@@ -540,7 +540,7 @@ module PuppetProfileParser
                       (?<log_level>[A-Z]+)\s+
                       \[(?<thread_id>\S+)\]\s+
                       \[(?<java_class>\S+)\]\s+
-                      (?:Puppet\s+)?PROFILE\s+\[(?<request_id>.+)\]\s+
+                      (?:Puppet\s+)?PROFILE\s+\[(?<request_id>[^\]]+)\]\s+
                       (?<message>.*)$/x
 
     # List of completed Trace instances


### PR DESCRIPTION
Prior to this PR, the DEFAULT_PARSER regex would create an invalid
match when the messages contained `]` character. This commit confines the
`request_id` section of the regex to between the `[]` characters.

This PR fixes an issue when running the profile that does puppet queries. This was seen when profiling a master, resulting in the following match. 

~~~
{ "timestamp"=>2018-04-09 15:47:28 -0700, 
"log_level"=>"INFO", 
"thread_id"=>"qtp1818666145-473512", 
"java_class"=>"puppetserver", 
"request_id"=>"917205680] 1.4.10.1.2.45.4.1 Submitted query 'nodes[certname", 
"message"=>"{ resources { type = 'Class' and title = 'Puppet_enterprise::Master::Pcp_broker' } and deactivated is null order by certname }': took 0.0720 seconds"
}
~~~