### PR TITLE
Addding profile summary task

### DIFF
--- a/files/puppet-profile-parser.rb
+++ b/files/puppet-profile-parser.rb
@@ -1,0 +1,1 @@
+../puppet-profile-parser.rb

--- a/tasks/show_summary.json
+++ b/tasks/show_summary.json
@@ -1,0 +1,12 @@
+{
+  "description": "Analyze puppetserver log with profiling information and produce a summary",
+  "parameters": {
+    "logs": {
+      "type": "Optional[String]",
+      "description": "One or more log files to analyze, space separated, can contain shell glob patterns and point to .gz files. Defaults to '/var/log/puppetlabs/puppetserver/puppetserver.log'"
+    }
+  },
+  "files": [
+    "puppet_profile_parser/files/puppet-profile-parser.rb"
+  ]
+}

--- a/tasks/show_summary.sh
+++ b/tasks/show_summary.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+LOGS=${PT_logs:-/var/log/puppetlabs/puppetserver/puppetserver.log}
+RUBY=$(which ruby||echo "/opt/puppetlabs/puppet/bin/ruby")
+
+echo "Analyzing logs: $LOGS"
+# we allog $LOGS to contain globbing characters
+# FIXME: potential security issue with allowing any logfile to be specified
+# Probably need to restrict to files inside /var/log/puppetlabs/puppetserver
+$RUBY ${PT__installdir}/puppet_profile_parser/files/puppet-profile-parser.rb ${LOGS}


### PR DESCRIPTION
Added a task to easily show the summary of the profiling log with Bolt or PE.

![image](https://user-images.githubusercontent.com/1586813/67196124-7d3c7b00-f3fa-11e9-850f-dd91c70f9924.png)

![image](https://user-images.githubusercontent.com/1586813/67196175-95ac9580-f3fa-11e9-8e78-195f377c9e91.png)
