### PR TITLE
Fix whitespace issue on duration EOL

### DIFF
--- a/puppet-profile-parser.rb
+++ b/puppet-profile-parser.rb
@@ -382,7 +382,7 @@ module PuppetProfileParser
     # Regex for extracting span id and duration
     COMMON_DATA = /(?<span_id>[\d\.]+)\s+
                    (?<message>.*)
-                   :\stook\s(?<duration>[\d\.]+)\sseconds$/x
+                   :\stook\s(?<duration>[\d\.]+)\sseconds\s*$/x
 
     FUNCTION_CALL = /Called (?<name>\S+)/
     RESOURCE_EVAL = /Evaluated resource (?<name>(?<puppet.resource_type>[\w:]+)\[(?<puppet.resource_title>.*)\])/


### PR DESCRIPTION
Prior to this commit, if there was extra whitespace at the end of the duration lines, they would be not be parsed, resulting in an empty file.

With this commit, we now consume the trailing whitespace.